### PR TITLE
Fix download file name for Linux

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -38,7 +38,7 @@ download_release() {
   version="$1"
   filename="$2"
 
-  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_$(get_platform)_$(get_arch).tar.gz"
+  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_$(get_platform)_$(get_arch).tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"


### PR DESCRIPTION
Fix asset file name to match current releases format for Linux : https://github.com/charmbracelet/glow/releases